### PR TITLE
Correct minor typo on an important button

### DIFF
--- a/frontend/src/components/PollDetailsPollFooter/PollDetailsPollFooter.vue
+++ b/frontend/src/components/PollDetailsPollFooter/PollDetailsPollFooter.vue
@@ -6,7 +6,7 @@
         v-if="!userAddress && isPollOngoing"
       >
         <connect-wallet
-          label="Connect you wallet to vote"
+          label="Connect your wallet to vote"
         />
       </div>
 


### PR DESCRIPTION
Super small typo correction, but on the primary button for placing a vote:

![image](https://user-images.githubusercontent.com/6567119/140622084-5681349d-bd88-47db-bec8-6c3005f2edcc.png)

Now reads "Connect your wallet to vote"